### PR TITLE
fix: heap sort not working

### DIFF
--- a/Source/Algorithms/HeapSort.js
+++ b/Source/Algorithms/HeapSort.js
@@ -29,11 +29,10 @@ function * heap_up ( size , items , i ){
     
     while ( i > 0 && items[root] < items[i]){
         
-        yield [ Alpha , i ]
-        yield [ Beta , root ]
-        
         [ items[i] , items[root] ] = [ items[root] , items[i] ];
         
+        yield [ Alpha , i ]
+        yield [ Beta , root ]
         yield [ Unsorted , i ]
         yield [ Unsorted , root ]
 


### PR DESCRIPTION
A fix for the heap sort not working because of the changing of items in-between yields.